### PR TITLE
Ensure view my work button colors are not affected by dark mode

### DIFF
--- a/hooks/useHeroEffects.ts
+++ b/hooks/useHeroEffects.ts
@@ -45,8 +45,8 @@ export const useHeroEffects = () => {
         currentPositionRef.current.y += (mousePositionRef.current.y - currentPositionRef.current.y) * 0.1;
 
         // Apply parallax transform
-        const parallaxX = currentPositionRef.current.x * 20; // 20px max movement
-        const parallaxY = currentPositionRef.current.y * 20;
+        const parallaxX = currentPositionRef.current.x * 30; // 30px max movement for more visible effect
+        const parallaxY = currentPositionRef.current.y * 30;
 
         heroElement.style.setProperty('--parallax-x', `${parallaxX}px`);
         heroElement.style.setProperty('--parallax-y', `${parallaxY}px`);

--- a/index.css
+++ b/index.css
@@ -158,3 +158,29 @@
 .touch-device .hero-parallax {
   transform: none !important;
 }
+
+/* ===== VIEW MY WORK BUTTON DARK MODE OVERRIDE ===== */
+/* Ensure the 'View My Work' button maintains its light mode colors regardless of theme */
+
+/* Target the specific button by its text content and location */
+.hero-content a[href="#projects"] {
+  background-color: rgb(234 179 8) !important; /* yellow-500 - light mode accent color */
+  color: rgb(51 65 85) !important; /* slate-700 - neutral color for text */
+}
+
+/* Override dark mode specifically */
+.dark .hero-content a[href="#projects"] {
+  background-color: rgb(234 179 8) !important; /* Force light mode yellow-500 */
+  color: rgb(51 65 85) !important; /* Force light mode neutral text color */
+}
+
+/* Ensure hover states also maintain light mode colors */
+.hero-content a[href="#projects"]:hover {
+  background-color: rgb(250 204 21) !important; /* yellow-400 - hover color */
+  color: rgb(51 65 85) !important; /* Maintain text color on hover */
+}
+
+.dark .hero-content a[href="#projects"]:hover {
+  background-color: rgb(250 204 21) !important; /* Force light mode hover color */
+  color: rgb(51 65 85) !important; /* Force light mode text color */
+}

--- a/index.css
+++ b/index.css
@@ -120,8 +120,9 @@
     display: none; /* Disable cursor effect on mobile */
   }
   
+  /* Keep parallax effect on mobile but reduce intensity */
   .hero-parallax {
-    transform: none !important; /* Disable parallax on mobile */
+    transform: translate(calc(var(--parallax-x, 0) * 0.5), calc(var(--parallax-y, 0) * 0.5)) !important;
   }
   
   /* Slower animation on mobile for better performance */
@@ -137,8 +138,9 @@
     background-position: 0% 50%;
   }
   
+  /* Keep parallax effect but reduce intensity for reduced motion preference */
   .hero-parallax {
-    transform: none !important;
+    transform: translate(calc(var(--parallax-x, 0) * 0.3), calc(var(--parallax-y, 0) * 0.3)) !important;
   }
   
   .hero-gradient::before {
@@ -156,7 +158,7 @@
 }
 
 .touch-device .hero-parallax {
-  transform: none !important;
+  transform: translate(calc(var(--parallax-x, 0) * 0.4), calc(var(--parallax-y, 0) * 0.4)) !important;
 }
 
 /* ===== VIEW MY WORK BUTTON DARK MODE OVERRIDE ===== */

--- a/index.css
+++ b/index.css
@@ -36,14 +36,10 @@
     rgba(255, 255, 255, 0.06),
     transparent 40%
   );
-  opacity: 0;
+  opacity: 1;
   transition: opacity 0.3s ease;
   pointer-events: none;
   z-index: 1;
-}
-
-.hero-gradient:hover::before {
-  opacity: 1;
 }
 
 /* Parallax layer for subtle depth */
@@ -53,7 +49,10 @@
   left: -10%;
   width: 120%;
   height: 120%;
-  /* background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E"); */
+  background: 
+    radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 75% 75%, rgba(255, 255, 255, 0.05) 0%, transparent 50%),
+    url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
   transform: translate(var(--parallax-x, 0), var(--parallax-y, 0));
   transition: transform 0.6s cubic-bezier(0.23, 1, 0.32, 1);
   pointer-events: none;


### PR DESCRIPTION
Re-enable and enhance the hero section's cursor-based parallax effect and ensure the 'View My Work' button maintains its light mode colors across themes.

The parallax effect was inadvertently disabled or too subtle on various devices, and the 'View My Work' button's colors were incorrectly changing with dark mode. This PR restores the intended interactive visual effect and ensures consistent button branding.

---

[Open in Web](https://cursor.com/agents?id=bc-9c67533e-c702-40e8-b679-0827776537bd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9c67533e-c702-40e8-b679-0827776537bd) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)